### PR TITLE
Error handling tweaks

### DIFF
--- a/remove_vpc.py
+++ b/remove_vpc.py
@@ -145,12 +145,13 @@ def main():
 
     Order of operation:
 
-    1.) Delete the internet gateway
-    2.) Delete subnets
-    3.) Delete route tables
-    4.) Delete network access lists
-    5.) Delete security groups
-    6.) Delete the VPC
+    1.) Confirm that the VPC has no allocated network interfaces
+    2.) Delete the internet gateway
+    3.) Delete subnets
+    4.) Delete route tables
+    5.) Delete network access lists
+    6.) Delete security groups
+    7.) Delete the VPC
     """
 
     # AWS Credentials

--- a/remove_vpc.py
+++ b/remove_vpc.py
@@ -12,176 +12,169 @@ from botocore.exceptions import ClientError
 
 
 def delete_igw(ec2, vpc_id):
-  """
+    """
   Detach and delete the internet gateway
   """
 
-  args = {
-    'Filters' : [
-      {
-        'Name' : 'attachment.vpc-id',
-        'Values' : [ vpc_id ]
-      }
-    ]
-  }
-
-  try:
-    igw = ec2.describe_internet_gateways(**args)['InternetGateways']
-  except ClientError as e:
-    print(e.response['Error']['Message'])
-
-  if igw:
-    igw_id = igw[0]['InternetGatewayId']
+    args = {"Filters": [{"Name": "attachment.vpc-id", "Values": [vpc_id]}]}
 
     try:
-      result = ec2.detach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
+        igw = ec2.describe_internet_gateways(**args)["InternetGateways"]
     except ClientError as e:
-      print(e.response['Error']['Message'])
+        print(e.response["Error"]["Message"])
 
-    try:
-      result = ec2.delete_internet_gateway(InternetGatewayId=igw_id)
-    except ClientError as e:
-      print(e.response['Error']['Message'])
+    if igw:
+        igw_id = igw[0]["InternetGatewayId"]
 
-  return
+        try:
+            result = ec2.detach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
+        except ClientError as e:
+            print(e.response["Error"]["Message"])
+
+        try:
+            result = ec2.delete_internet_gateway(InternetGatewayId=igw_id)
+        except ClientError as e:
+            print(e.response["Error"]["Message"])
+
+    return
 
 
 def delete_subs(ec2, args):
-  """
+    """
   Delete the subnets
   """
 
-  try:
-    subs = ec2.describe_subnets(**args)['Subnets']
-  except ClientError as e:
-    print(e.response['Error']['Message'])
+    try:
+        subs = ec2.describe_subnets(**args)["Subnets"]
+    except ClientError as e:
+        print(e.response["Error"]["Message"])
 
-  if subs:
-    for sub in subs:
-      sub_id = sub['SubnetId']
+    if subs:
+        for sub in subs:
+            sub_id = sub["SubnetId"]
 
-      try:
-        result = ec2.delete_subnet(SubnetId=sub_id)
-      except ClientError as e:
-        print(e.response['Error']['Message'])
+            try:
+                result = ec2.delete_subnet(SubnetId=sub_id)
+            except ClientError as e:
+                print(e.response["Error"]["Message"])
 
-  return
+    return
 
 
 def delete_rtbs(ec2, args):
-  """
+    """
   Delete the route tables
   """
 
-  try:
-    rtbs = ec2.describe_route_tables(**args)['RouteTables']
-  except ClientError as e:
-    print(e.response['Error']['Message'])
+    try:
+        rtbs = ec2.describe_route_tables(**args)["RouteTables"]
+    except ClientError as e:
+        print(e.response["Error"]["Message"])
 
-  if rtbs:
-    for rtb in rtbs:
-      main = 'false'
-      for assoc in rtb['Associations']:
-        main = assoc['Main']
-      if main == True:
-        continue
-      rtb_id = rtb['RouteTableId']
-        
-      try:
-        result = ec2.delete_route_table(RouteTableId=rtb_id)
-      except ClientError as e:
-        print(e.response['Error']['Message'])
+    if rtbs:
+        for rtb in rtbs:
+            main = "false"
+            for assoc in rtb["Associations"]:
+                main = assoc["Main"]
+            if main == True:
+                continue
+            rtb_id = rtb["RouteTableId"]
 
-  return
+            try:
+                result = ec2.delete_route_table(RouteTableId=rtb_id)
+            except ClientError as e:
+                print(e.response["Error"]["Message"])
+
+    return
 
 
 def delete_acls(ec2, args):
-  """
+    """
   Delete the network access lists (NACLs)
   """
 
-  try:
-    acls = ec2.describe_network_acls(**args)['NetworkAcls']
-  except ClientError as e:
-    print(e.response['Error']['Message'])
+    try:
+        acls = ec2.describe_network_acls(**args)["NetworkAcls"]
+    except ClientError as e:
+        print(e.response["Error"]["Message"])
 
-  if acls:
-    for acl in acls:
-      default = acl['IsDefault']
-      if default == True:
-        continue
-      acl_id = acl['NetworkAclId']
+    if acls:
+        for acl in acls:
+            default = acl["IsDefault"]
+            if default == True:
+                continue
+            acl_id = acl["NetworkAclId"]
 
-      try:
-        result = ec2.delete_network_acl(NetworkAclId=acl_id)
-      except ClientError as e:
-        print(e.response['Error']['Message'])
+            try:
+                result = ec2.delete_network_acl(NetworkAclId=acl_id)
+            except ClientError as e:
+                print(e.response["Error"]["Message"])
 
-  return
+    return
 
 
 def delete_sgps(ec2, args):
-  """
+    """
   Delete any security groups
   """
 
-  try:
-    sgps = ec2.describe_security_groups(**args)['SecurityGroups']
-  except ClientError as e:
-    print(e.response['Error']['Message'])
+    try:
+        sgps = ec2.describe_security_groups(**args)["SecurityGroups"]
+    except ClientError as e:
+        print(e.response["Error"]["Message"])
 
-  if sgps:
-    for sgp in sgps:
-      default = sgp['GroupName']
-      if default == 'default':
-        continue
-      sg_id = sgp['GroupId']
+    if sgps:
+        for sgp in sgps:
+            default = sgp["GroupName"]
+            if default == "default":
+                continue
+            sg_id = sgp["GroupId"]
 
-      try:
-        result = ec2.delete_security_group(GroupId=sg_id)
-      except ClientError as e:
-        print(e.response['Error']['Message'])
+            try:
+                result = ec2.delete_security_group(GroupId=sg_id)
+            except ClientError as e:
+                print(e.response["Error"]["Message"])
 
-  return
+    return
 
 
 def delete_vpc(ec2, vpc_id, region):
-  """
+    """
   Delete the VPC
   """
 
-  try:
-    result = ec2.delete_vpc(VpcId=vpc_id)
-  except ClientError as e:
-    print(e.response['Error']['Message'])
+    try:
+        result = ec2.delete_vpc(VpcId=vpc_id)
+    except ClientError as e:
+        print(e.response["Error"]["Message"])
 
-  else:
-    print('VPC {} has been deleted from the {} region.'.format(vpc_id, region))
+    else:
+        print("VPC {} has been deleted from the {} region.".format(vpc_id, region))
 
-  return
+    return
 
 
 def get_regions(ec2):
-  """
+    """
   Return all AWS regions
   """
 
-  regions = []
+    regions = []
 
-  try:
-    aws_regions = ec2.describe_regions()['Regions']
-  except ClientError as e:
-    print(e.response['Error']['Message'])
+    try:
+        aws_regions = ec2.describe_regions()["Regions"]
+    except ClientError as e:
+        print(e.response["Error"]["Message"])
 
-  else:
-    for region in aws_regions:
-      regions.append(region['RegionName'])
+    else:
+        for region in aws_regions:
+            regions.append(region["RegionName"])
 
-  return regions
+    return regions
 
 
 def main(profile):
-  """
+    """
   Do the work..
 
   Order of operation:
@@ -191,66 +184,63 @@ def main(profile):
   3.) Delete route tables
   4.) Delete network access lists
   5.) Delete security groups
-  6.) Delete the VPC 
+  6.) Delete the VPC
   """
 
-  # AWS Credentials
-  # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
+    # AWS Credentials
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
 
-  session = boto3.Session(profile_name=profile)
-  ec2 = session.client('ec2', region_name='us-east-1')
+    session = boto3.Session(profile_name=profile)
+    ec2 = session.client("ec2", region_name="us-east-1")
 
-  regions = get_regions(ec2)
+    regions = get_regions(ec2)
 
-  for region in regions:
+    for region in regions:
 
-    ec2 = session.client('ec2', region_name=region)
+        ec2 = session.client("ec2", region_name=region)
 
-    try:
-      attribs = ec2.describe_account_attributes(AttributeNames=[ 'default-vpc' ])['AccountAttributes']
-    except ClientError as e:
-      print(e.response['Error']['Message'])
-      return
+        try:
+            attribs = ec2.describe_account_attributes(AttributeNames=["default-vpc"])[
+                "AccountAttributes"
+            ]
+        except ClientError as e:
+            print(e.response["Error"]["Message"])
+            return
 
-    else:
-      vpc_id = attribs[0]['AttributeValues'][0]['AttributeValue']
+        else:
+            vpc_id = attribs[0]["AttributeValues"][0]["AttributeValue"]
 
-    if vpc_id == 'none':
-      print('VPC (default) was not found in the {} region.'.format(region))
-      continue
+        if vpc_id == "none":
+            print("VPC (default) was not found in the {} region.".format(region))
+            continue
 
-    # Are there any existing resources?  Since most resources attach an ENI, let's check..
+        # Are there any existing resources?  Since most resources attach an ENI, let's check..
 
-    args = {
-      'Filters' : [
-        {
-          'Name' : 'vpc-id',
-          'Values' : [ vpc_id ]
-        }
-      ]
-    }
+        args = {"Filters": [{"Name": "vpc-id", "Values": [vpc_id]}]}
 
-    try:
-      eni = ec2.describe_network_interfaces(**args)['NetworkInterfaces']
-    except ClientError as e:
-      print(e.response['Error']['Message'])
-      return
+        try:
+            eni = ec2.describe_network_interfaces(**args)["NetworkInterfaces"]
+        except ClientError as e:
+            print(e.response["Error"]["Message"])
+            return
 
-    if eni:
-      print('VPC {} has existing resources in the {} region.'.format(vpc_id, region))
-      continue
+        if eni:
+            print(
+                "VPC {} has existing resources in the {} region.".format(vpc_id, region)
+            )
+            continue
 
-    result = delete_igw(ec2, vpc_id)
-    result = delete_subs(ec2, args)
-    result = delete_rtbs(ec2, args)
-    result = delete_acls(ec2, args)
-    result = delete_sgps(ec2, args)
-    result = delete_vpc(ec2, vpc_id, region)
+        result = delete_igw(ec2, vpc_id)
+        result = delete_subs(ec2, args)
+        result = delete_rtbs(ec2, args)
+        result = delete_acls(ec2, args)
+        result = delete_sgps(ec2, args)
+        result = delete_vpc(ec2, vpc_id, region)
 
-  return
+    return
 
 
 if __name__ == "__main__":
 
-  main(profile = '<YOUR_PROFILE>')
+    main(profile="<YOUR_PROFILE>")
 

--- a/remove_vpc.py
+++ b/remove_vpc.py
@@ -6,6 +6,7 @@ Python Version: 3.7.0
 Boto3 Version: 1.7.50
 
 """
+import sys
 
 import boto3
 from botocore.exceptions import ClientError
@@ -13,110 +14,70 @@ from botocore.exceptions import ClientError
 
 def delete_igw(ec2, vpc_id):
     """
-  Detach and delete the internet gateway
-  """
+    Detach and delete the internet gateway
+    """
 
     args = {"Filters": [{"Name": "attachment.vpc-id", "Values": [vpc_id]}]}
+    igws = ec2.describe_internet_gateways(**args)["InternetGateways"]
 
-    try:
-        igw = ec2.describe_internet_gateways(**args)["InternetGateways"]
-    except ClientError as e:
-        print(e.response["Error"]["Message"])
+    for igw in igws:
+        igw_id = igw["InternetGatewayId"]
 
-    if igw:
-        igw_id = igw[0]["InternetGatewayId"]
-
-        try:
-            result = ec2.detach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
-        except ClientError as e:
-            print(e.response["Error"]["Message"])
-
-        try:
-            result = ec2.delete_internet_gateway(InternetGatewayId=igw_id)
-        except ClientError as e:
-            print(e.response["Error"]["Message"])
-
-    return
+        ec2.detach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
+        ec2.delete_internet_gateway(InternetGatewayId=igw_id)
 
 
 def delete_subs(ec2, args):
     """
-  Delete the subnets
-  """
+    Delete the subnets
+    """
 
-    try:
-        subs = ec2.describe_subnets(**args)["Subnets"]
-    except ClientError as e:
-        print(e.response["Error"]["Message"])
+    subs = ec2.describe_subnets(**args)["Subnets"]
 
-    if subs:
-        for sub in subs:
-            sub_id = sub["SubnetId"]
-
-            try:
-                result = ec2.delete_subnet(SubnetId=sub_id)
-            except ClientError as e:
-                print(e.response["Error"]["Message"])
-
-    return
+    for sub in subs:
+        sub_id = sub["SubnetId"]
+        ec2.delete_subnet(SubnetId=sub_id)
 
 
 def delete_rtbs(ec2, args):
     """
-  Delete the route tables
-  """
+    Delete the route tables
+    """
 
-    try:
-        rtbs = ec2.describe_route_tables(**args)["RouteTables"]
-    except ClientError as e:
-        print(e.response["Error"]["Message"])
+    rtbs = ec2.describe_route_tables(**args)["RouteTables"]
 
     if rtbs:
         for rtb in rtbs:
-            main = "false"
+            main = False
             for assoc in rtb["Associations"]:
                 main = assoc["Main"]
-            if main == True:
-                continue
-            rtb_id = rtb["RouteTableId"]
-
-            try:
-                result = ec2.delete_route_table(RouteTableId=rtb_id)
-            except ClientError as e:
-                print(e.response["Error"]["Message"])
-
-    return
+                if not main:
+                    rtb_id = rtb["RouteTableId"]
+                    ec2.delete_route_table(RouteTableId=rtb_id)
 
 
 def delete_acls(ec2, args):
     """
-  Delete the network access lists (NACLs)
-  """
+    Delete the network access lists (NACLs)
+    """
 
     try:
         acls = ec2.describe_network_acls(**args)["NetworkAcls"]
     except ClientError as e:
         print(e.response["Error"]["Message"])
 
-    if acls:
-        for acl in acls:
-            default = acl["IsDefault"]
-            if default == True:
-                continue
+    for acl in acls:
+        is_default = acl["IsDefault"]
+        if not is_default:
             acl_id = acl["NetworkAclId"]
-
-            try:
-                result = ec2.delete_network_acl(NetworkAclId=acl_id)
-            except ClientError as e:
-                print(e.response["Error"]["Message"])
-
-    return
+            ec2.delete_network_acl(NetworkAclId=acl_id)
+            break
 
 
 def delete_sgps(ec2, args):
     """
-  Delete any security groups
-  """
+    Delete any security groups
+    """
 
     try:
         sgps = ec2.describe_security_groups(**args)["SecurityGroups"]
@@ -129,63 +90,74 @@ def delete_sgps(ec2, args):
             if default == "default":
                 continue
             sg_id = sgp["GroupId"]
-
-            try:
-                result = ec2.delete_security_group(GroupId=sg_id)
-            except ClientError as e:
-                print(e.response["Error"]["Message"])
-
-    return
+            ec2.delete_security_group(GroupId=sg_id)
 
 
 def delete_vpc(ec2, vpc_id, region):
     """
-  Delete the VPC
-  """
+    Delete the VPC
+    """
 
-    try:
-        result = ec2.delete_vpc(VpcId=vpc_id)
-    except ClientError as e:
-        print(e.response["Error"]["Message"])
-
-    else:
-        print("VPC {} has been deleted from the {} region.".format(vpc_id, region))
-
-    return
+    ec2.delete_vpc(VpcId=vpc_id)
+    print(f"VPC {vpc_id} has been deleted from the {region} region.")
 
 
 def get_regions(ec2):
     """
-  Return all AWS regions
-  """
+    Return all AWS regions
+    """
 
-    regions = []
+    aws_regions = ec2.describe_regions()["Regions"]
+    return [region["RegionName"] for region in aws_regions]
 
+
+def process_region(ec2, region):
     try:
-        aws_regions = ec2.describe_regions()["Regions"]
+        attribs = ec2.describe_account_attributes(AttributeNames=["default-vpc"])
     except ClientError as e:
-        print(e.response["Error"]["Message"])
+        # this can happen with e.g. SCPs preventing access to a particular region:
+        raise RuntimeError(
+            "Unable to query VPCs in {}: {}".format(
+                region, e.response["Error"]["Message"]
+            )
+        ) from e
 
+    assert 1 == len(attribs["AccountAttributes"])
+    vpc_id = attribs["AccountAttributes"][0]["AttributeValues"][0]["AttributeValue"]
+
+    if vpc_id == "none":
+        raise RuntimeError(f"Default VPC was not found in the {region} region.")
+
+    # Are there any existing resources?  Since most resources attach an ENI, let's check..
+
+    args = {"Filters": [{"Name": "vpc-id", "Values": [vpc_id]}]}
+    eni = ec2.describe_network_interfaces(**args)["NetworkInterfaces"]
+
+    if eni:
+        print(f"VPC {vpc_id} has existing resources in the {region} region.")
     else:
-        for region in aws_regions:
-            regions.append(region["RegionName"])
-
-    return regions
+        print(f"Deleting unused VPC {vpc_id} in the {region} region.")
+        delete_igw(ec2, vpc_id)
+        delete_subs(ec2, args)
+        delete_rtbs(ec2, args)
+        delete_acls(ec2, args)
+        delete_sgps(ec2, args)
+        delete_vpc(ec2, vpc_id, region)
 
 
 def main():
     """
-  Do the work..
+    Do the work..
 
-  Order of operation:
+    Order of operation:
 
-  1.) Delete the internet gateway
-  2.) Delete subnets
-  3.) Delete route tables
-  4.) Delete network access lists
-  5.) Delete security groups
-  6.) Delete the VPC
-  """
+    1.) Delete the internet gateway
+    2.) Delete subnets
+    3.) Delete route tables
+    4.) Delete network access lists
+    5.) Delete security groups
+    6.) Delete the VPC
+    """
 
     # AWS Credentials
     # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
@@ -196,48 +168,12 @@ def main():
     regions = get_regions(ec2)
 
     for region in regions:
-
         ec2 = session.client("ec2", region_name=region)
-
         try:
-            attribs = ec2.describe_account_attributes(AttributeNames=["default-vpc"])[
-                "AccountAttributes"
-            ]
-        except ClientError as e:
-            print(e.response["Error"]["Message"])
-            return
-
-        else:
-            vpc_id = attribs[0]["AttributeValues"][0]["AttributeValue"]
-
-        if vpc_id == "none":
-            print("VPC (default) was not found in the {} region.".format(region))
+            process_region(ec2, region)
+        except Exception as exc:
+            print(f"Unable to process region {region}: {exc}", file=sys.stderr)
             continue
-
-        # Are there any existing resources?  Since most resources attach an ENI, let's check..
-
-        args = {"Filters": [{"Name": "vpc-id", "Values": [vpc_id]}]}
-
-        try:
-            eni = ec2.describe_network_interfaces(**args)["NetworkInterfaces"]
-        except ClientError as e:
-            print(e.response["Error"]["Message"])
-            return
-
-        if eni:
-            print(
-                "VPC {} has existing resources in the {} region.".format(vpc_id, region)
-            )
-            continue
-
-        result = delete_igw(ec2, vpc_id)
-        result = delete_subs(ec2, args)
-        result = delete_rtbs(ec2, args)
-        result = delete_acls(ec2, args)
-        result = delete_sgps(ec2, args)
-        result = delete_vpc(ec2, vpc_id, region)
-
-    return
 
 
 if __name__ == "__main__":

--- a/remove_vpc.py
+++ b/remove_vpc.py
@@ -173,7 +173,7 @@ def get_regions(ec2):
     return regions
 
 
-def main(profile):
+def main():
     """
   Do the work..
 
@@ -190,7 +190,7 @@ def main(profile):
     # AWS Credentials
     # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
 
-    session = boto3.Session(profile_name=profile)
+    session = boto3.Session()
     ec2 = session.client("ec2", region_name="us-east-1")
 
     regions = get_regions(ec2)
@@ -241,6 +241,4 @@ def main(profile):
 
 
 if __name__ == "__main__":
-
-    main(profile="<YOUR_PROFILE>")
-
+    main()

--- a/remove_vpc.py
+++ b/remove_vpc.py
@@ -61,10 +61,7 @@ def delete_acls(ec2, args):
     Delete the network access lists (NACLs)
     """
 
-    try:
-        acls = ec2.describe_network_acls(**args)["NetworkAcls"]
-    except ClientError as e:
-        print(e.response["Error"]["Message"])
+    acls = ec2.describe_network_acls(**args)["NetworkAcls"]
 
     for acl in acls:
         is_default = acl["IsDefault"]
@@ -79,10 +76,7 @@ def delete_sgps(ec2, args):
     Delete any security groups
     """
 
-    try:
-        sgps = ec2.describe_security_groups(**args)["SecurityGroups"]
-    except ClientError as e:
-        print(e.response["Error"]["Message"])
+    sgps = ec2.describe_security_groups(**args)["SecurityGroups"]
 
     if sgps:
         for sgp in sgps:


### PR DESCRIPTION
I ran into a couple of things while testing this:

* Using the profile name from the environment avoids needing to manage it in code
* I consolidated most of the error handling code into a single exception block which avoids some of the edge  cases where e.g. it would attempt to delete an IGW even if detaching it failed for some reason
* Regions which cannot be accessed using the active credentials display an error but don't cause the program to exit